### PR TITLE
Added region as an option for file-syncer

### DIFF
--- a/file_syncer/run.py
+++ b/file_syncer/run.py
@@ -39,6 +39,8 @@ def run():
     parser = OptionParser(usage=usage)
     parser.add_option('--provider', dest='provider', default='CLOUDFILES_US',
                       help='Provider to use')
+    parser.add_option('--region', dest='region', default=None,
+                      help='Region to use (ex: ORD)')
     parser.add_option('--username', dest='api_username',
                       help='API username')
     parser.add_option('--key', dest='api_key',
@@ -95,6 +97,7 @@ def run():
 
     syncer = FileSyncer(directory=directory,
                         provider_cls=get_driver(provider),
+                        region=options.region,
                         username=options.api_username,
                         api_key=options.api_key,
                         container_name=options.container_name,

--- a/file_syncer/run.py
+++ b/file_syncer/run.py
@@ -40,7 +40,8 @@ def run():
     parser.add_option('--provider', dest='provider', default='CLOUDFILES_US',
                       help='Provider to use')
     parser.add_option('--region', dest='region', default=None,
-                      help='Region to use (ex: ORD)')
+                      help='Region to use if a Libcloud driver supports \
+                        multiple regions (e.g. ORD for CloudFiles provider)')
     parser.add_option('--username', dest='api_username',
                       help='API username')
     parser.add_option('--key', dest='api_key',
@@ -97,6 +98,7 @@ def run():
 
     syncer = FileSyncer(directory=directory,
                         provider_cls=get_driver(provider),
+                        provider=provider,
                         region=options.region,
                         username=options.api_username,
                         api_key=options.api_key,

--- a/file_syncer/syncer.py
+++ b/file_syncer/syncer.py
@@ -45,9 +45,10 @@ from file_syncer.constants import MANIFEST_FILE
 class FileSyncer(object):
     def __init__(self, directory, provider_cls, username, api_key,
                  container_name, cache_path, exclude_patterns,
-                 logger, concurrency=20, retry_limit=3):
+                 logger, region=None, concurrency=20, retry_limit=3):
         self._directory = directory
         self._provider_cls = provider_cls
+        self._region = region
         self._username = username
         self._api_key = api_key
         self._container_name = container_name
@@ -99,7 +100,10 @@ class FileSyncer(object):
         self._container = container
 
     def _get_driver_instance(self):
-        driver = self._provider_cls(self._username, self._api_key)
+        driver = self._provider_cls(
+            self._username, self._api_key,
+            ex_force_service_region=self._region
+        )
         return driver
 
     def _include_file(self, file_name):

--- a/file_syncer/syncer.py
+++ b/file_syncer/syncer.py
@@ -110,7 +110,7 @@ class FileSyncer(object):
         args = (self._username, self._api_key)
         kwargs = {}
 
-        force_region = PROVIDER_HAS_REGION.get(self._provider)
+        force_region = PROVIDER_HAS_REGION.get(self._provider, None)
         if self._region and force_region:
             kwargs[force_region] = self._region
 


### PR DESCRIPTION
Before this it would default to the first region given from the
libcloud service catalog. If we pass a region to the driver then
it will use that region
