### PR TITLE
fix options - auto-content-type

### DIFF
--- a/file_syncer/run.py
+++ b/file_syncer/run.py
@@ -117,7 +117,7 @@ def run():
                         exclude_patterns=exclude_patterns,
                         logger=logger,
                         concurrency=int(options.concurrency),
-                        no_content_type=options.no_content_type,
+                        auto_content_type=options.auto_content_type,
                         ignore_symlinks=options.ignore_symlinks)
     if options.restore:
         syncer.restore()

--- a/file_syncer/syncer.py
+++ b/file_syncer/syncer.py
@@ -287,7 +287,7 @@ class FileSyncer(object):
 
         try:
             driver.upload_object(file_path=file_path, container=container,
-                                 object_name=name, extra=extra)
+                                 object_name=file_path, extra=extra)
 
         except LibcloudError, e:
             self._logger.error('Failed to upload object "%(name)s": %(error)s',
@@ -305,7 +305,7 @@ class FileSyncer(object):
 
         self._clear_retry(name)
         self._uploaded.append(item)
-        self._logger.debug('Object uploaded: %(name)s', {'name': name})
+        self._logger.debug('Object uploaded: %(name)s', {'name': file_path})
 
     def _get_local_files(self, directory):
         """
@@ -320,8 +320,8 @@ class FileSyncer(object):
         for (dirpath, dirnames, filenames) in files:
             for name in filenames:
 
-                file_path = os.path.join(base_path, dirpath, name)
-                remote_name = self._get_item_remote_name(name=name,
+                file_path = os.path.join(directory, name)
+                remote_name = self._get_item_remote_name(name=file_path,
                                                          file_path=file_path)
 
                 if not self._include_file(remote_name):
@@ -332,7 +332,7 @@ class FileSyncer(object):
                 mtime = os.path.getmtime(file_path)
                 md5_hash = None
 
-                item = {'name': name, 'remote_name': remote_name,
+                item = {'name': file_path, 'remote_name': remote_name,
                         'path': file_path, 'last_modified': mtime,
                         'md5_hash': md5_hash}
                 result[remote_name] = item

--- a/file_syncer/syncer.py
+++ b/file_syncer/syncer.py
@@ -320,9 +320,9 @@ class FileSyncer(object):
         for (dirpath, dirnames, filenames) in files:
             for name in filenames:
 
-                file_path = os.path.join(directory, name)
-                remote_name = self._get_item_remote_name(name=file_path,
-                                                         file_path=file_path)
+                file_path = os.path.join(base_path, dirpath, name)
+                # remote_name = self._get_item_remote_name(name=file_path, file_path=file_path)
+                remote_name = os.path.join(dirpath, name)
 
                 if not self._include_file(remote_name):
                     self._logger.debug('File %(name)s is excluded skipping it',
@@ -332,7 +332,7 @@ class FileSyncer(object):
                 mtime = os.path.getmtime(file_path)
                 md5_hash = None
 
-                item = {'name': file_path, 'remote_name': remote_name,
+                item = {'name': remote_name, 'remote_name': remote_name,
                         'path': file_path, 'last_modified': mtime,
                         'md5_hash': md5_hash}
                 result[remote_name] = item

--- a/file_syncer/syncer.py
+++ b/file_syncer/syncer.py
@@ -320,7 +320,7 @@ class FileSyncer(object):
         for (dirpath, dirnames, filenames) in files:
             for name in filenames:
 
-                file_path = os.path.join(base_path, dirpath, name)
+                file_path = os.path.join(base_path, name)
                 # remote_name = self._get_item_remote_name(name=file_path, file_path=file_path)
                 remote_name = os.path.join(dirpath, name)
 


### PR DESCRIPTION
Hello :)

It seems not all the options were swapped from "no-content-type" to "auto-content-type", and, should no content type be given, results in an error:

Traceback (most recent call last):
  File "/usr/local/bin/file-syncer", line 10, in <module>
    execfile(**file**)
  File "/var/www/vhosts/latina.com/docroot/src/file-syncer/bin/file-syncer", line 4, in <module>
    run()
  File "/var/www/vhosts/latina.com/docroot/src/file-syncer/file_syncer/run.py", line 120, in run
    no_content_type=options.no_content_type,
AttributeError: Values instance has no attribute 'no_content_type'
Exception KeyError: KeyError(140361824529776,) in <module 'threading' from '/usr/lib/python2.7/threading.pyc'> ignored

  Thanks!
